### PR TITLE
Update jar reference in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,5 @@
     "minimum-stability": "dev",
     "autoload": { },
     "target-dir": "",
-    "bin": ["selenium-server-standalone-2.39.0.jar"]
+    "bin": ["selenium-server-standalone-2.42.2.jar"]
 }


### PR DESCRIPTION
The reference to the selenium standalone server is out of date (2.39.0 instead of 2.42.2), and is updated in this commit to avoid the message "Skipped installation of bin selenium-server-standalone-2.39.0.jar for package netwing/selenium-server-standalone: file not found in package" when running composer update and restore the initial purpose of this package.
